### PR TITLE
sleep after adding latest found nets to message not before

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -->
 
 ## [Unreleased]
+## [0.1.1] - 2022-02-19
+### Fixed
+- Sleep after adding the latest found networks to the asyncio message, not
+  before
 
 ## Released
 ## [0.1.0] - 2022-02-19

--- a/wifi_manager.py
+++ b/wifi_manager.py
@@ -370,10 +370,10 @@ class WiFiManager(object):
                 found_nets = wh.get_wifi_networks_sorted(rescan=True,
                                                          scan_if_empty=True)
 
+                msg.set(found_nets)
+
                 # wait for specified time
                 time.sleep_ms(scan_interval)
-
-                msg.set(found_nets)
             except KeyboardInterrupt:
                 break
 


### PR DESCRIPTION
Sleeping in scan thread is done after setting the latest scan data to the message