### PR TITLE
Allow custom logger for picoweb

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -->
 
 ## [Unreleased]
+## [1.2.0] - 2022-03-06
+### Added
+- Custom logger can be provided to `run` function to enable different logging
+  levels of Picoweb other than `DEBUG`
+
+### Changed
+- Neopixel is no longer fading while scan thread is running to reduce CPU load
+- `gc.collect()` is no longer called on `latest_scan` property access
+
 ## [1.1.0] - 2022-02-27
 ### Added
 - Property `connection_timeout` to control WiFi connection timeout instead of
@@ -112,8 +121,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `sendfile` function implemented in same way as on Micropythons PicoWeb
 
 <!-- Links -->
-[Unreleased]: https://github.com/brainelectronics/Micropython-ESP-WiFi-Manager/compare/1.1.0...develop
+[Unreleased]: https://github.com/brainelectronics/Micropython-ESP-WiFi-Manager/compare/1.2.0...develop
 
+[1.2.0]: https://github.com/brainelectronics/Micropython-ESP-WiFi-Manager//tree/1.2.0
 [1.1.0]: https://github.com/brainelectronics/Micropython-ESP-WiFi-Manager//tree/1.1.0
 [1.0.0]: https://github.com/brainelectronics/Micropython-ESP-WiFi-Manager//tree/1.0.0
 [0.1.1]: https://github.com/brainelectronics/Micropython-ESP-WiFi-Manager//tree/0.1.1

--- a/wifi_manager/version.py
+++ b/wifi_manager/version.py
@@ -1,2 +1,3 @@
-__version__ = '1.1.0'
+__version_info__ = ('1', '2', '0')
+__version__ = '.'.join(__version_info__)
 __author__ = 'brainelectronics'

--- a/wifi_manager/wifi_manager.py
+++ b/wifi_manager/wifi_manager.py
@@ -527,10 +527,6 @@ class WiFiManager(object):
 
     @property
     def latest_scan(self) -> Union[List[dict], str]:
-        # gc.collect()
-        # free = gc.mem_free()
-        # self.logger.debug('Free memory: {}'.format(free))
-
         latest_scan_result = self._scan_net_msg.value()
         self.logger.info('Requested latest scan result: {}'.
                          format(latest_scan_result))

--- a/wifi_manager/wifi_manager.py
+++ b/wifi_manager/wifi_manager.py
@@ -527,9 +527,10 @@ class WiFiManager(object):
 
     @property
     def latest_scan(self) -> Union[List[dict], str]:
-        gc.collect()
-        free = gc.mem_free()
-        self.logger.debug('Free memory: {}'.format(free))
+        # gc.collect()
+        # free = gc.mem_free()
+        # self.logger.debug('Free memory: {}'.format(free))
+
         latest_scan_result = self._scan_net_msg.value()
         self.logger.info('Requested latest scan result: {}'.
                          format(latest_scan_result))

--- a/wifi_manager/wifi_manager.py
+++ b/wifi_manager/wifi_manager.py
@@ -850,7 +850,8 @@ class WiFiManager(object):
     def run(self,
             host: str = '0.0.0.0',
             port: int = 80,
-            debug: bool = False) -> None:
+            debug: bool = False,
+            log=None) -> None:
         """
         Run the web application
 
@@ -861,6 +862,8 @@ class WiFiManager(object):
         :param      debug:  Flag to automatically reload for code changes and
                             show debugger content
         :type       debug:  bool, optional
+        :param      log:    Logger of Picoweb
+        :type       log:    logging.Logger
         """
         self.logger.debug('Run app on {}:{} with debug: {}'.format(host,
                                                                    port,
@@ -868,7 +871,7 @@ class WiFiManager(object):
         try:
             # self.app.run()
             # self.app.run(debug=debug)
-            self.app.run(host=host, port=port, debug=debug)
+            self.app.run(host=host, port=port, debug=debug, log=log)
         except KeyboardInterrupt:
             self.logger.debug('Catched KeyboardInterrupt at run of web app')
         except Exception as e:

--- a/wifi_manager/wifi_manager.py
+++ b/wifi_manager/wifi_manager.py
@@ -444,7 +444,7 @@ class WiFiManager(object):
         :param      lock:           The lock object
         :type       lock:           _thread.lock
         """
-        pixel.fading = True
+        # pixel.fading = True
 
         while lock.locked():
             try:
@@ -459,7 +459,7 @@ class WiFiManager(object):
             except KeyboardInterrupt:
                 break
 
-        pixel.fading = False
+        # pixel.fading = False
         print('Finished scanning')
 
     @property


### PR DESCRIPTION
### Added
- Custom logger can be provided to `run` function to enable different logging levels of Picoweb other than `DEBUG`

### Changed
- Neopixel is no longer fading while scan thread is running to reduce CPU load
- `gc.collect()` is no longer called on `latest_scan` property access