### PR TITLE
Remove neopixel usage and remove latest scan logging

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -->
 
 ## [Unreleased]
+## [1.4.0] - 2022-03-18
+### Changed
+- Scan data is no logger logged with info level on `latest_scan` property
+  access to reduce time before data return
+- Neopixel is no longer used to allow user of lib to use it as desired by its
+  higher level application
+
 ## [1.3.0] - 2022-03-11
 ### Changed
 - Index page uses cards instead of list to show available pages
@@ -129,8 +136,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `sendfile` function implemented in same way as on Micropythons PicoWeb
 
 <!-- Links -->
-[Unreleased]: https://github.com/brainelectronics/Micropython-ESP-WiFi-Manager/compare/1.3.0...develop
+[Unreleased]: https://github.com/brainelectronics/Micropython-ESP-WiFi-Manager/compare/1.4.0...develop
 
+[1.4.0]: https://github.com/brainelectronics/Micropython-ESP-WiFi-Manager//tree/1.4.0
 [1.3.0]: https://github.com/brainelectronics/Micropython-ESP-WiFi-Manager//tree/1.3.0
 [1.2.0]: https://github.com/brainelectronics/Micropython-ESP-WiFi-Manager//tree/1.2.0
 [1.1.0]: https://github.com/brainelectronics/Micropython-ESP-WiFi-Manager//tree/1.1.0

--- a/changelog.md
+++ b/changelog.md
@@ -14,8 +14,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -->
 
 ## [Unreleased]
-## [1.4.0] - 2022-03-18
+## [1.4.0] - 2022-03-20
+### Added
+- Virtual oneshot timer is created and started on `latest_scan` property
+  access to stop the scanning thread again after 10.5x of `scan_interval`.
+  This reduces CPU load and avoids unused scans.
+
 ### Changed
+- Scanning thread is started  on `latest_scan` property access
 - Scan data is no logger logged with info level on `latest_scan` property
   access to reduce time before data return
 - Neopixel is no longer used to allow user of lib to use it as desired by its

--- a/changelog.md
+++ b/changelog.md
@@ -23,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Scanning thread is started  on `latest_scan` property access
 - Scan data is no logger logged with info level on `latest_scan` property
-  access to reduce time before data return
+  access to reduce time before data return, see [#11][ref-issue-11]
 - Neopixel is no longer used to allow user of lib to use it as desired by its
   higher level application
 
@@ -152,6 +152,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [0.1.1]: https://github.com/brainelectronics/Micropython-ESP-WiFi-Manager//tree/0.1.1
 [0.1.0]: https://github.com/brainelectronics/Micropython-ESP-WiFi-Manager//tree/0.1.0
 
+[ref-issue-11]: https://github.com/brainelectronics/Micropython-ESP-WiFi-Manager/issues/11
 [ref-pypi]: https://pypi.org/
 [ref-pfalcon-picoweb-sdist-upip]: https://github.com/pfalcon/picoweb/blob/b74428ebdde97ed1795338c13a3bdf05d71366a0/sdist_upip.py
 [ref-be-micropython-module]: https://github.com/brainelectronics/micropython-modules/tree/1.1.0

--- a/wifi_manager/version.py
+++ b/wifi_manager/version.py
@@ -1,3 +1,3 @@
-__version_info__ = ('1', '3', '0')
+__version_info__ = ('1', '4', '0')
 __version__ = '.'.join(__version_info__)
 __author__ = 'brainelectronics'

--- a/wifi_manager/wifi_manager.py
+++ b/wifi_manager/wifi_manager.py
@@ -540,10 +540,13 @@ class WiFiManager(object):
 
     @property
     def latest_scan(self) -> Union[List[dict], str]:
-        latest_scan_result = self._scan_net_msg.value()
-        self.logger.info('Requested latest scan result: {}'.
-                         format(latest_scan_result))
-        return latest_scan_result
+        """
+        Get lastest scanned networks.
+
+        :returns:   Dictionary of available networks
+        :rtype:     Union[List[dict], str]
+        """
+        return self._scan_net_msg.value()
 
     def _render_index_page(self, available_pages: dict) -> str:
         """

--- a/wifi_manager/wifi_manager.py
+++ b/wifi_manager/wifi_manager.py
@@ -32,7 +32,6 @@ import ure as re
 # custom packages
 from be_helpers.generic_helper import GenericHelper
 from be_helpers.message import Message
-from be_helpers.led_helper import Neopixel
 from be_helpers.path_helper import PathHelper
 from be_helpers.wifi_helper import WifiHelper
 
@@ -58,9 +57,6 @@ class WiFiManager(object):
 
         self.app = picoweb.WebApp(pkg='/lib')
         self.wh = WifiHelper()
-        self.pixel = Neopixel()
-        self.pixel.color = 'yellow'
-        self.pixel.intensity = 20
 
         self.event_sinks = set()
 
@@ -438,7 +434,6 @@ class WiFiManager(object):
         return self._configured_networks
 
     def _scan(self,
-              pixel: Neopixel,
               wh: WifiHelper,
               msg: Message,
               scan_interval: int,
@@ -446,8 +441,6 @@ class WiFiManager(object):
         """
         Scan for available networks.
 
-        :param      pixel:          Neopixel helper object
-        :type       pixel:          Neopixel
         :param      wh:             Wifi helper object
         :type       wh:             WifiHelper
         :param      msg:            The shared message from this thread
@@ -457,8 +450,6 @@ class WiFiManager(object):
         :param      lock:           The lock object
         :type       lock:           _thread.lock
         """
-        # pixel.fading = True
-
         while lock.locked():
             try:
                 # rescan for available networks
@@ -472,7 +463,6 @@ class WiFiManager(object):
             except KeyboardInterrupt:
                 break
 
-        # pixel.fading = False
         print('Finished scanning')
 
     @property
@@ -525,7 +515,6 @@ class WiFiManager(object):
 
             # parameters of the _scan function
             params = (
-                self.pixel,
                 self.wh,
                 self._scan_net_msg,
                 self._scan_interval,


### PR DESCRIPTION
### Added
- Virtual oneshot timer is created and started on `latest_scan` property access to stop the scanning thread again after 10.5x of `scan_interval`. This reduces CPU load and avoids unused scans.

### Changed
- Scanning thread is started  on `latest_scan` property access
- Scan data is no logger logged with info level on `latest_scan` property access to reduce time before data return #11 
- Neopixel is no longer used to allow user of lib to use it as desired by its higher level application