### PR TITLE
Create AccessPoint with unique name

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -13,7 +13,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 -->
 
-## [Unreleased]
+<!-- ## [Unreleased] -->
+
+## Released
+## [1.5.0] - 2022-04-16
+### Changed
+- `start_config` creates an AccessPoint named `WiFiManager_xxxx` with `xxxx`
+  as the first four characters of the UUID of the device
+
 ## [1.4.0] - 2022-03-20
 ### Added
 - Virtual oneshot timer is created and started on `latest_scan` property
@@ -142,8 +149,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `sendfile` function implemented in same way as on Micropythons PicoWeb
 
 <!-- Links -->
-[Unreleased]: https://github.com/brainelectronics/Micropython-ESP-WiFi-Manager/compare/1.4.0...develop
+[Unreleased]: https://github.com/brainelectronics/Micropython-ESP-WiFi-Manager/compare/1.5.0...develop
 
+[1.5.0]: https://github.com/brainelectronics/Micropython-ESP-WiFi-Manager//tree/1.5.0
 [1.4.0]: https://github.com/brainelectronics/Micropython-ESP-WiFi-Manager//tree/1.4.0
 [1.3.0]: https://github.com/brainelectronics/Micropython-ESP-WiFi-Manager//tree/1.3.0
 [1.2.0]: https://github.com/brainelectronics/Micropython-ESP-WiFi-Manager//tree/1.2.0
@@ -152,6 +160,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [0.1.1]: https://github.com/brainelectronics/Micropython-ESP-WiFi-Manager//tree/0.1.1
 [0.1.0]: https://github.com/brainelectronics/Micropython-ESP-WiFi-Manager//tree/0.1.0
 
+[ref-issue-15]: https://github.com/brainelectronics/Micropython-ESP-WiFi-Manager/issues/15
 [ref-issue-11]: https://github.com/brainelectronics/Micropython-ESP-WiFi-Manager/issues/11
 [ref-pypi]: https://pypi.org/
 [ref-pfalcon-picoweb-sdist-upip]: https://github.com/pfalcon/picoweb/blob/b74428ebdde97ed1795338c13a3bdf05d71366a0/sdist_upip.py

--- a/simulation/src/wifi_manager/wifi_manager.py
+++ b/simulation/src/wifi_manager/wifi_manager.py
@@ -219,8 +219,11 @@ class WiFiManager(object):
 
     def start_config(self) -> None:
         """Start WiFi manager accesspoint and webserver."""
-        self.logger.info('Starting Manager with AccessPoint')
-        result = self.wh.create_ap(ssid='WiFiManager',
+        ap_name = 'WiFiManager_{}'.format(
+            GenericHelper.get_uuid(4).decode('ascii'))
+        self.logger.info('Starting WiFiManager as AccessPoint "{}"'.
+                         format(ap_name))
+        result = self.wh.create_ap(ssid=ap_name,
                                    password='',
                                    channel=11,
                                    timeout=5)

--- a/wifi_manager/version.py
+++ b/wifi_manager/version.py
@@ -1,3 +1,3 @@
-__version_info__ = ('1', '4', '0')
+__version_info__ = ('1', '5', '0')
 __version__ = '.'.join(__version_info__)
 __author__ = 'brainelectronics'

--- a/wifi_manager/wifi_manager.py
+++ b/wifi_manager/wifi_manager.py
@@ -211,8 +211,11 @@ class WiFiManager(object):
 
     def start_config(self) -> None:
         """Start WiFi manager accesspoint and webserver."""
-        self.logger.info('Starting Manager with AccessPoint')
-        result = self.wh.create_ap(ssid='WiFiManager',
+        ap_name = 'WiFiManager_{}'.format(
+            GenericHelper.get_uuid(4).decode('ascii'))
+        self.logger.info('Starting WiFiManager as AccessPoint "{}"'.
+                         format(ap_name))
+        result = self.wh.create_ap(ssid=ap_name,
                                    password='',
                                    channel=11,
                                    timeout=5)


### PR DESCRIPTION
### Changed
- `start_config` creates an AccessPoint named `WiFiManager_xxxx` with `xxxx` as the first four characters of the UUID of the device