### PR TITLE
Feature/support mip: put boot.py and main.py under /lib/wifi_manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,21 @@ upip.install('micropython-esp-wifi-manager')
 # dependencies will be installed automatically
 ```
 
+#### Hook the WiFi Manager logic into `/boot.py` and `/main.py`
+
+Because the `mip` installation will not install files outside of `/lib`, to run the WiFi Manager at startup,
+add this line to your `/boot.py`:
+
+```python
+import wifi_manager.boot
+```
+
+And also add this line to your `/main.py`, before your application code:
+
+```python
+import wifi_manager.main
+```
+
 #### Specific version
 
 Install a specific, fixed package version of this lib on the MicroPython device

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
     "urls": [
         [
-            "boot.py",
+            "/boot.py",
             "github:brainelectronics/Micropython-ESP-WiFi-Manager/boot.py"
         ],
         [
-            "main.py",
+            "/main.py",
             "github:brainelectronics/Micropython-ESP-WiFi-Manager/main.py"
         ],
         [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,14 @@
 {
     "urls": [
         [
+            "boot.py",
+            "github:brainelectronics/Micropython-ESP-WiFi-Manager/boot.py"
+        ],
+        [
+            "main.py",
+            "github:brainelectronics/Micropython-ESP-WiFi-Manager/main.py"
+        ],
+        [
             "wifi_manager/__init__.py",
             "github:brainelectronics/Micropython-ESP-WiFi-Manager/wifi_manager/__init__.py"
         ],

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
     "urls": [
         [
-            "/boot.py",
+            "wifi_manager/boot.py",
             "github:brainelectronics/Micropython-ESP-WiFi-Manager/boot.py"
         ],
         [
-            "/main.py",
+            "wifi_manager/main.py",
             "github:brainelectronics/Micropython-ESP-WiFi-Manager/main.py"
         ],
         [

--- a/simulation/templates/select.tpl.html
+++ b/simulation/templates/select.tpl.html
@@ -45,7 +45,7 @@
         </div>
         <input type="text" class="w-100" name="ssid" id="ssid" placeholder="Custom Network Name">
         <br>
-        <input type="password" class="w-100" name="password" id="password" placeholder="Passwort" onkeydown="if(event.keyCode==13)document.getElementById('save').click()"/>
+        <input type="password" class="w-100" name="password" id="password" placeholder="Password" onkeydown="if(event.keyCode==13)document.getElementById('save').click()"/>
         <div class="list-group">
           <button type="submit" id="save" value="Save" class="btn btn-lg btn-primary list-group-item active">Submit</button>
           <form>

--- a/simulation/templates/wifi_select_loader.tpl.html
+++ b/simulation/templates/wifi_select_loader.tpl.html
@@ -22,7 +22,7 @@
           {% endfor %}
         </select>
         <input type="text" name="ssid" id="ssid" placeholder="Custom Network Name">
-        <input type="password" name="password" id="password" placeholder="Passwort" onkeydown="if(event.keyCode==13)document.getElementById('save').click()"/>
+        <input type="password" name="password" id="password" placeholder="Password" onkeydown="if(event.keyCode==13)document.getElementById('save').click()"/>
         <input type="submit" class="button" id="save" value="Save">
       </form>
       <form>

--- a/templates/select.tpl
+++ b/templates/select.tpl
@@ -50,7 +50,7 @@
         </div>
         <input type="text" class="w-100" name="ssid" id="ssid" placeholder="Custom Network Name">
         <br>
-        <input type="password" class="w-100" name="password" id="password" placeholder="Passwort" onkeydown="if(event.keyCode==13)document.getElementById('save').click()"/>
+        <input type="password" class="w-100" name="password" id="password" placeholder="Password" onkeydown="if(event.keyCode==13)document.getElementById('save').click()"/>
         <div class="list-group">
           <button type="submit" id="save" value="Save" class="btn btn-lg btn-primary list-group-item active">Submit</button>
           <form>

--- a/templates/wifi_select_loader.tpl
+++ b/templates/wifi_select_loader.tpl
@@ -22,7 +22,7 @@
           {% endfor %}
         </select>
         <input type="text" name="ssid" id="ssid" placeholder="Custom Network Name">
-        <input type="password" name="password" id="password" placeholder="Passwort" onkeydown="if(event.keyCode==13)document.getElementById('save').click()"/>
+        <input type="password" name="password" id="password" placeholder="Password" onkeydown="if(event.keyCode==13)document.getElementById('save').click()"/>
         <input type="submit" class="button" id="save" value="Save">
       </form>
       <form>


### PR DESCRIPTION
Because installing using `mip` won't write outside of the `/lib` directory, the files `/boot.py` and `/main.py` must be put under `/lib`. The logical place to put these is under `/lib/wifi_manager`.

This PR adds these two files to the `package.json` and also adds documentation to the `README.md` file describing how to invoke this logic from the user's `/main.py` and `/boot.py` files.