### PR TITLE
Add boot and main files to package json

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,4 +58,5 @@ jobs:
             --package_file package.json \
             --validate \
             --ignore-version \
-            --ignore-deps
+            --ignore-deps \
+            --ignore-boot-main

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ MicroPython WiFi Manager to configure and connect to networks
 	- [Upload files to board](#upload-files-to-board)
 		- [Install package](#install-package)
 		- [General](#general)
+		- [Hook the WiFi Manager boot logic](#hook-the-wifi-manager-boot-logic)
 		- [Specific version](#specific-version)
 		- [Test version](#test-version)
 		- [Manually](#manually)
@@ -103,6 +104,23 @@ For MicroPython versions below 1.19.1 use the `upip` package instead of `mip`
 import upip
 upip.install('micropython-esp-wifi-manager')
 # dependencies will be installed automatically
+```
+
+#### Hook the WiFi Manager boot logic
+
+The `boot.py` and `main.py` files of this package are installed into `/lib` of
+the MicroPython device by `mip`. They are fully functional and without any
+other dependencies or MicroPython port specific commands. Simply add the
+following line to the `boot.py` file of your device.
+
+```python
+from wifi_manager import boot
+```
+
+And also add this line to your `main.py`, before your application code
+
+```python
+from wifi_manager import main
 ```
 
 #### Specific version

--- a/boot.py
+++ b/boot.py
@@ -5,36 +5,20 @@
 boot script, do initial stuff here, similar to the setup() function on Arduino
 """
 
-import esp
 import gc
 import network
-import time
+from time import sleep
 
-# custom packages
-from be_helpers.led_helper import Led
-
-
-# set clock speed to 240MHz instead of default 160MHz
-# machine.freq(240000000)
-
-# disable ESP os debug output
-esp.osdebug(None)
-
-led = Led()
-led.flash(amount=3, delay_ms=50)
-led.turn_on()
 
 station = network.WLAN(network.STA_IF)
 if station.active() and station.isconnected():
     station.disconnect()
-    time.sleep(1)
+    sleep(1)
 station.active(False)
-time.sleep(1)
+sleep(1)
 station.active(True)
-
-led.turn_off()
 
 # run garbage collector at the end to clean up
 gc.collect()
 
-print('Finished booting')
+print('Finished booting steps of MicroPython WiFiManager')

--- a/changelog.md
+++ b/changelog.md
@@ -20,6 +20,17 @@ r"^\#\# \[\d{1,}[.]\d{1,}[.]\d{1,}\] \- \d{4}\-\d{2}-\d{2}$"
 <!-- ## [Unreleased] -->
 
 ## Released
+## [1.12.0] - 2023-06-12
+### Added
+- Instructions for using this package `boot.py` and `main.py` files
+- `boot.py` and `main.py` are part of `package.json` and are installed into `wifi_manager/`, see #32 and #33
+
+### Changed
+- Ignore boot and main files during `package.json` validation
+
+### Removed
+- No device specific dependencies in `boot.py` to LED
+
 ## [1.11.0] - 2023-05-27
 ### Added
 - `package.json` file and installation instruction for `mip` usage, see #30
@@ -261,8 +272,9 @@ r"^\#\# \[\d{1,}[.]\d{1,}[.]\d{1,}\] \- \d{4}\-\d{2}-\d{2}$"
 - `sendfile` function implemented in same way as on Micropythons PicoWeb
 
 <!-- Links -->
-[Unreleased]: https://github.com/brainelectronics/Micropython-ESP-WiFi-Manager/compare/1.11.0...develop
+[Unreleased]: https://github.com/brainelectronics/Micropython-ESP-WiFi-Manager/compare/1.12.0...develop
 
+[1.12.0]: https://github.com/brainelectronics/Micropython-ESP-WiFi-Manager//tree/1.12.0
 [1.11.0]: https://github.com/brainelectronics/Micropython-ESP-WiFi-Manager//tree/1.11.0
 [1.10.0]: https://github.com/brainelectronics/Micropython-ESP-WiFi-Manager//tree/1.10.0
 [1.9.0]: https://github.com/brainelectronics/Micropython-ESP-WiFi-Manager//tree/1.9.0

--- a/main.py
+++ b/main.py
@@ -22,4 +22,4 @@ if result is False:
 else:
     print('Successfully connected to a network :)')
 
-print('Returning to REPL')
+print('Finished booting steps of MicroPython WiFiManager')

--- a/package.json
+++ b/package.json
@@ -5,6 +5,14 @@
             "github:brainelectronics/Micropython-ESP-WiFi-Manager/wifi_manager/__init__.py"
         ],
         [
+            "wifi_manager/boot.py",
+            "github:brainelectronics/Micropython-ESP-WiFi-Manager/boot.py"
+        ],
+        [
+            "wifi_manager/main.py",
+            "github:brainelectronics/Micropython-ESP-WiFi-Manager/main.py"
+        ],
+        [
             "wifi_manager/version.py",
             "github:brainelectronics/Micropython-ESP-WiFi-Manager/wifi_manager/version.py"
         ],

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -3,5 +3,5 @@
 flake8>=5.0.0,<6
 coverage>=6.4.2,<7
 nose2>=0.12.0,<1
-setup2upypackage>=0.3.0,<1
+setup2upypackage>=0.4.0,<1
 -r simulation/requirements.txt


### PR DESCRIPTION
### Added
- Instructions for using this package `boot.py` and `main.py` files
- `boot.py` and `main.py` are part of `package.json` and are installed into `wifi_manager/`, see #32 and #33

### Changed
- Ignore boot and main files during `package.json` validation

### Removed
- No device specific dependencies in `boot.py` to LED
