### PR TITLE
Prepare ned reduced memory usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,16 +111,17 @@ upip.install('micropython-esp-wifi-manager')
 The `boot.py` and `main.py` files of this package are installed into `/lib` of
 the MicroPython device by `mip`. They are fully functional and without any
 other dependencies or MicroPython port specific commands. Simply add the
-following line to the `boot.py` file of your device.
+following line to the `boot.py` file of your device. *The following commands
+are not working if this package got installed by `upip`*
 
 ```python
-from wifi_manager import boot
+import wifi_manager.boot
 ```
 
 And also add this line to your `main.py`, before your application code
 
 ```python
-from wifi_manager import main
+import wifi_manager.main
 ```
 
 #### Specific version

--- a/changelog.md
+++ b/changelog.md
@@ -20,6 +20,14 @@ r"^\#\# \[\d{1,}[.]\d{1,}[.]\d{1,}\] \- \d{4}\-\d{2}-\d{2}$"
 <!-- ## [Unreleased] -->
 
 ## Released
+## [1.12.1] - 2023-06-16
+### Added
+- `pkg_resources` to `setup.py` and `package.json` as version 0.2.1 to prepare #33
+
+### Fixed
+- Instructions for using this package `boot.py` and `main.py` files in README
+- `microdot` added to the simulation requirements
+
 ## [1.12.0] - 2023-06-12
 ### Added
 - Instructions for using this package `boot.py` and `main.py` files
@@ -272,8 +280,9 @@ r"^\#\# \[\d{1,}[.]\d{1,}[.]\d{1,}\] \- \d{4}\-\d{2}-\d{2}$"
 - `sendfile` function implemented in same way as on Micropythons PicoWeb
 
 <!-- Links -->
-[Unreleased]: https://github.com/brainelectronics/Micropython-ESP-WiFi-Manager/compare/1.12.0...develop
+[Unreleased]: https://github.com/brainelectronics/Micropython-ESP-WiFi-Manager/compare/1.12.1...develop
 
+[1.12.1]: https://github.com/brainelectronics/Micropython-ESP-WiFi-Manager//tree/1.12.1
 [1.12.0]: https://github.com/brainelectronics/Micropython-ESP-WiFi-Manager//tree/1.12.0
 [1.11.0]: https://github.com/brainelectronics/Micropython-ESP-WiFi-Manager//tree/1.11.0
 [1.10.0]: https://github.com/brainelectronics/Micropython-ESP-WiFi-Manager//tree/1.10.0

--- a/package.json
+++ b/package.json
@@ -49,6 +49,10 @@
             "github:brainelectronics/Micropython-ESP-WiFi-Manager/utemplate/source.py"
         ],
         [
+            "pkg_resources/pkg_resources.py",
+            "github:brainelectronics/Micropython-ESP-WiFi-Manager/pkg_resources/pkg_resources.py"
+        ],
+        [
             "static/css/bootstrap.min.css",
             "github:brainelectronics/Micropython-ESP-WiFi-Manager/static/css/bootstrap.min.css"
         ],
@@ -82,7 +86,8 @@
         ]
     ],
     "deps": [
-        ["github:brainelectronics/micropython-modules", "develop"]
+        ["github:brainelectronics/micropython-modules", "develop"],
+        ["pkg_resources", "0.2.1"]
     ],
     "version": "1.11.0"
 }

--- a/pkg_resources/pkg_resources.py
+++ b/pkg_resources/pkg_resources.py
@@ -1,0 +1,28 @@
+import uio
+
+c = {}
+
+
+def resource_stream(package, resource):
+    if package not in c:
+        try:
+            if package:
+                p = __import__(package + ".R", None, None, True)
+            else:
+                p = __import__("R")
+            c[package] = p.R
+        except ImportError:
+            if package:
+                p = __import__(package)
+                d = p.__path__
+            else:
+                d = "."
+            #            if d[0] != "/":
+            #                import uos
+            #                d = uos.getcwd() + "/" + d
+            c[package] = d + "/"
+
+    p = c[package]
+    if isinstance(p, dict):
+        return uio.BytesIO(p[resource])
+    return open(p + resource, "rb")

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ setup(
         'wifi_manager',
         'microdot',
         'utemplate',
+        'pkg_resources',
     ],
     # Although 'package_data' is the preferred approach, in some case you may
     # need to place data files outside of your packages. See:

--- a/simulation/requirements.txt
+++ b/simulation/requirements.txt
@@ -5,3 +5,4 @@ jinja2>=3.0.2,<4
 PyYAML>=5.4.1,<6
 netifaces>=0.11.0,<1
 pycrypto>=2.6.1,<3
+microdot>=1.2.4,<2


### PR DESCRIPTION
This prepares additional files and fixes for #33 if old `upip` and PyPi or Test PyPi is used

### Added
- `pkg_resources` to `setup.py` and `package.json` as version 0.2.1 to prepare #33

### Fixed
- Instructions for using this package `boot.py` and `main.py` files in README
- `microdot` added to the simulation requirements